### PR TITLE
Popupを開いたときのタブと異なるタブの情報を取得してしまう不具合を修正した

### DIFF
--- a/src/ts/popup.ts
+++ b/src/ts/popup.ts
@@ -9,6 +9,7 @@ function captureTitleAndUrlAsync() {
     return new Promise((resolve)=>{
         chrome.tabs.query({
             active: true,
+            currentWindow: true,
         }, (tabs)=> {
             resolve(tabs.shift());
         });


### PR DESCRIPTION
Fix #5 popupと同じWindowに所属するActiveなTabを取得することで解決する。